### PR TITLE
Fix plugin-check and align release version flow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,6 +72,16 @@ jobs:
           echo "version=$plugin_version" >> "$GITHUB_OUTPUT"
           echo "tag=v$plugin_version" >> "$GITHUB_OUTPUT"
 
+      - name: Ensure release version was prepared before push
+        run: |
+          head_subject="$(git log -1 --pretty=%s | tr -d '\r')"
+          expected_subject="chore(release): v${{ steps.meta.outputs.version }}"
+
+          if [ "$head_subject" != "$expected_subject" ]; then
+            echo "::error::Expected the top commit on main to be '$expected_subject' so CI releases the exact version prepared locally. Found '$head_subject'."
+            exit 1
+          fi
+
       - name: Check release state
         id: existing
         env:

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -23,6 +23,21 @@ done <"$tmp_refs"
 current_branch="$(git branch --show-current 2>/dev/null)"
 [ "$current_branch" = "main" ] || exit 0
 
+printf '\nPreparing release version before pushing main...\n'
+
+if ! node scripts/release.mjs prepare-push "${TRPL_RELEASE_TYPE:-patch}"; then
+  status=$?
+
+  if [ "$status" = "10" ]; then
+    printf '\nA release version commit was created locally.\n' >&2
+    printf 'Run `git push origin main` again so the new versioned commit is included.\n\n' >&2
+  else
+    printf '\nRelease preparation failed, so the push was stopped.\n\n' >&2
+  fi
+
+  exit 1
+fi
+
 version="$(node -p "require('./package.json').version")"
 commit_subject="$(git log -1 --pretty=%s)"
 

--- a/README.md
+++ b/README.md
@@ -206,8 +206,9 @@ No. Scheduled cleanup also moves matching files into plugin Trash first. The mai
 ## Release Workflow
 
 - Run `npm install` once so Husky installs the local git hooks.
-- Pushing `main` now syncs the current plugin state to the local WordPress.org SVN checkout before GitHub push completes.
-- GitHub Actions only validates the plugin, publishes the GitHub release, generates release notes from commit messages, and deploys the docs site.
+- The first push to `main` now prepares a local release commit such as `chore(release): v2.2.1` and stops the push so you can review it.
+- Re-run `git push origin main` after that release commit is created. The second push syncs the exact same version to the local WordPress.org SVN checkout before GitHub push completes.
+- GitHub Actions now only validates the plugin, creates the Git tag and GitHub release for the version already prepared locally, generates release notes from commit messages, and deploys the docs site.
 - To skip the local WordPress.org deploy for one push, use `TRPL_SKIP_WPORG_DEPLOY=1 git push origin main`.
 
 ## Screenshot Workflow

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -48,6 +48,12 @@ async function main() {
 			console.log(`Version is in sync at ${readVersionMetadata().pluginVersion}.`);
 			break;
 
+		case 'prepare-push': {
+			const releaseType = firstNonFlag(args) || process.env.TRPL_RELEASE_TYPE || 'patch';
+			preparePushRelease(releaseType);
+			break;
+		}
+
 		case 'bump': {
 			const nextVersion = resolveNextVersion(firstNonFlag(args));
 			updateProjectVersion(nextVersion);
@@ -89,7 +95,7 @@ async function main() {
 		}
 
 		default:
-			throw new Error(`Unknown command "${command}". Use verify, bump, deploy, notes, or ship.`);
+			throw new Error(`Unknown command "${command}". Use verify, prepare-push, bump, deploy, notes, or ship.`);
 	}
 }
 
@@ -195,7 +201,39 @@ function updateProjectVersion(nextVersion) {
 	packageJson.version = nextVersion;
 	fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
 
+	const packageLockPath = path.join(rootDir, 'package-lock.json');
+	if (fs.existsSync(packageLockPath)) {
+		const packageLock = JSON.parse(fs.readFileSync(packageLockPath, 'utf8'));
+		packageLock.version = nextVersion;
+		if (packageLock.packages?.['']) {
+			packageLock.packages[''].version = nextVersion;
+		}
+		fs.writeFileSync(packageLockPath, `${JSON.stringify(packageLock, null, 2)}\n`);
+	}
+
 	console.log(`Version bumped from ${currentVersion} to ${nextVersion}.`);
+}
+
+function preparePushRelease(requestedVersion) {
+	assertCommandAvailable('git');
+	assertGitBranchIsMain();
+	verifyVersionConsistency();
+
+	const currentVersion = readVersionMetadata().pluginVersion;
+	const releaseCommitSubject = `chore(release): v${currentVersion}`;
+	const headSubject = runCapture('git', ['log', '-1', '--pretty=%s'], rootDir).trim();
+
+	if (headSubject === releaseCommitSubject) {
+		console.log(`Release commit already prepared for v${currentVersion}.`);
+		return;
+	}
+
+	const nextVersion = resolveNextVersion(requestedVersion);
+	updateProjectVersion(nextVersion);
+	run('git', ['add', 'thumbnail-remover.php', 'readme.txt', 'README.md', 'package.json', 'package-lock.json'], rootDir);
+	run('git', ['commit', '-m', `chore(release): v${nextVersion}`], rootDir);
+	console.log(`Prepared release version v${nextVersion}. Re-run the push so the new release commit is included.`);
+	process.exit(10);
 }
 
 function deployToWordPressOrg(message, options = {}) {

--- a/thumbnail-remover.php
+++ b/thumbnail-remover.php
@@ -23,6 +23,7 @@ define( 'TRPL_JOBS_OPTION', 'trpl_jobs' );
 define( 'TRPL_ACTIVITY_LOG_OPTION', 'trpl_activity_log' );
 define( 'TRPL_SCHEDULE_SETTINGS_OPTION', 'trpl_schedule_settings' );
 define( 'TRPL_SCHEDULE_STATUS_OPTION', 'trpl_schedule_status' );
+define( 'TRPL_CACHE_VERSION_OPTION', 'trpl_cache_version' );
 define( 'TRPL_TRASH_DIRNAME', 'trpl-trash' );
 define( 'TRPL_SCHEDULE_EVENT_HOOK', 'trpl_run_scheduled_cleanup' );
 define( 'TRPL_SCHEDULE_PROCESS_HOOK', 'trpl_process_scheduled_cleanup' );
@@ -517,12 +518,53 @@ function trpl_get_upload_base_url() {
 	return trailingslashit( $upload_dir['baseurl'] );
 }
 
+function trpl_get_cache_version() {
+	$version = (int) get_option( TRPL_CACHE_VERSION_OPTION, 1 );
+
+	return $version > 0 ? $version : 1;
+}
+
+function trpl_get_cache_key( $suffix ) {
+	return 'trpl_' . sanitize_key( $suffix ) . '_' . trpl_get_cache_version();
+}
+
+function trpl_get_cache_ttl() {
+	return 10 * MINUTE_IN_SECONDS;
+}
+
+function trpl_bump_cache_version() {
+	update_option( TRPL_CACHE_VERSION_OPTION, time(), false );
+}
+
+function trpl_maybe_invalidate_media_cache_by_meta( $meta_id, $object_id, $meta_key ) {
+	if ( ! get_post( $object_id ) ) {
+		return;
+	}
+
+	if ( in_array( $meta_key, array( '_wp_attached_file', '_wp_attachment_metadata', '_thumbnail_id' ), true ) ) {
+		trpl_bump_cache_version();
+	}
+}
+
+add_action( 'add_attachment', 'trpl_bump_cache_version' );
+add_action( 'edit_attachment', 'trpl_bump_cache_version' );
+add_action( 'delete_attachment', 'trpl_bump_cache_version' );
+add_action( 'added_post_meta', 'trpl_maybe_invalidate_media_cache_by_meta', 10, 3 );
+add_action( 'updated_post_meta', 'trpl_maybe_invalidate_media_cache_by_meta', 10, 3 );
+add_action( 'deleted_post_meta', 'trpl_maybe_invalidate_media_cache_by_meta', 10, 3 );
+
 function trpl_get_trash_base_dir() {
 	return trpl_get_upload_base_dir() . TRPL_TRASH_DIRNAME . '/';
 }
 
 function trpl_get_all_image_sizes() {
 	global $_wp_additional_image_sizes;
+
+	static $sizes = null;
+
+	if ( null !== $sizes ) {
+		return $sizes;
+	}
 
 	$sizes = array();
 
@@ -548,6 +590,12 @@ function trpl_get_all_image_sizes() {
 }
 
 function trpl_get_size_dimension_lookup() {
+	static $lookup = null;
+
+	if ( null !== $lookup ) {
+		return $lookup;
+	}
+
 	$lookup = array();
 
 	foreach ( trpl_get_all_image_sizes() as $size_name => $details ) {
@@ -641,6 +689,11 @@ function trpl_relative_path_to_folder( $relative_path ) {
 }
 
 function trpl_get_upload_folders_with_count() {
+	$cached_folders = get_transient( trpl_get_cache_key( 'upload_folders' ) );
+	if ( is_array( $cached_folders ) ) {
+		return $cached_folders;
+	}
+
 	$attachments = trpl_get_image_attachment_ids();
 	$folders = array();
 
@@ -658,11 +711,17 @@ function trpl_get_upload_folders_with_count() {
 	}
 
 	krsort( $folders );
+	set_transient( trpl_get_cache_key( 'upload_folders' ), $folders, trpl_get_cache_ttl() );
 
 	return $folders;
 }
 
 function trpl_get_available_dates() {
+	$cached_dates = get_transient( trpl_get_cache_key( 'available_dates' ) );
+	if ( is_array( $cached_dates ) ) {
+		return $cached_dates;
+	}
+
 	$folders = trpl_get_upload_folders_with_count();
 	$available_dates = array();
 
@@ -675,10 +734,17 @@ function trpl_get_available_dates() {
 		}
 	}
 
+	set_transient( trpl_get_cache_key( 'available_dates' ), $available_dates, trpl_get_cache_ttl() );
+
 	return $available_dates;
 }
 
 function trpl_get_image_attachment_ids() {
+	$cached_attachments = get_transient( trpl_get_cache_key( 'image_attachment_ids' ) );
+	if ( is_array( $cached_attachments ) ) {
+		return array_map( 'intval', $cached_attachments );
+	}
+
 	$attachments = get_posts(
 		array(
 			'post_type' => 'attachment',
@@ -691,6 +757,8 @@ function trpl_get_image_attachment_ids() {
 			'no_found_rows' => true,
 		)
 	);
+
+	set_transient( trpl_get_cache_key( 'image_attachment_ids' ), $attachments, trpl_get_cache_ttl() );
 
 	return array_map( 'intval', $attachments );
 }
@@ -711,10 +779,17 @@ function trpl_attachment_matches_folders( $attachment_id, $selected_folders ) {
 }
 
 function trpl_get_attachment_files( $attachment_id ) {
+	static $records_cache = array();
+
+	if ( isset( $records_cache[ $attachment_id ] ) ) {
+		return $records_cache[ $attachment_id ];
+	}
+
 	$records = array();
 	$relative_path = get_post_meta( $attachment_id, '_wp_attached_file', true );
 
 	if ( empty( $relative_path ) ) {
+		$records_cache[ $attachment_id ] = $records;
 		return $records;
 	}
 
@@ -783,6 +858,8 @@ function trpl_get_attachment_files( $attachment_id ) {
 		}
 	}
 
+	$records_cache[ $attachment_id ] = $records;
+
 	return $records;
 }
 
@@ -833,25 +910,22 @@ function trpl_build_regeneration_attachment_ids( $selected_folders ) {
 }
 
 function trpl_is_attachment_used( $attachment_id ) {
-	global $wpdb;
+	static $usage_results = array();
+
+	if ( isset( $usage_results[ $attachment_id ] ) ) {
+		return $usage_results[ $attachment_id ];
+	}
 
 	$attachment = get_post( $attachment_id );
 	if ( ! $attachment ) {
+		$usage_results[ $attachment_id ] = false;
 		return false;
 	}
 
-	if ( ! empty( $attachment->post_parent ) && 'trash' !== get_post_status( $attachment->post_parent ) ) {
-		return true;
-	}
+	$usage_lookup = trpl_get_attachment_usage_lookup();
 
-	$featured_usage = (int) $wpdb->get_var(
-		$wpdb->prepare(
-			"SELECT COUNT(*) FROM {$wpdb->postmeta} WHERE meta_key = '_thumbnail_id' AND meta_value = %s",
-			(string) $attachment_id
-		)
-	);
-
-	if ( $featured_usage > 0 ) {
+	if ( isset( $usage_lookup[ $attachment_id ] ) ) {
+		$usage_results[ $attachment_id ] = true;
 		return true;
 	}
 
@@ -865,32 +939,119 @@ function trpl_is_attachment_used( $attachment_id ) {
 	);
 
 	foreach ( array_unique( $needles ) as $needle ) {
-		$like = '%' . $wpdb->esc_like( $needle ) . '%';
-
-		$content_usage = (int) $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type != 'attachment' AND post_status NOT IN ('trash', 'auto-draft') AND post_content LIKE %s",
-				$like
-			)
-		);
-
-		if ( $content_usage > 0 ) {
-			return true;
-		}
-
-		$builder_usage = (int) $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT COUNT(*) FROM {$wpdb->postmeta} pm INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id WHERE p.post_type != 'attachment' AND p.post_status NOT IN ('trash', 'auto-draft') AND pm.meta_value LIKE %s",
-				$like
-			)
-		);
-
-		if ( $builder_usage > 0 ) {
+		if ( trpl_attachment_usage_search_exists( $needle ) ) {
+			$usage_results[ $attachment_id ] = true;
 			return true;
 		}
 	}
 
+	$usage_results[ $attachment_id ] = false;
+
 	return false;
+}
+
+function trpl_get_attachment_usage_lookup() {
+	global $wpdb;
+	static $lookup = null;
+
+	if ( null !== $lookup ) {
+		return $lookup;
+	}
+
+	$lookup = array();
+	$attachment_ids = trpl_get_image_attachment_ids();
+
+	if ( empty( $attachment_ids ) ) {
+		return $lookup;
+	}
+
+	$cache_key = 'attachment_usage_lookup_' . trpl_get_cache_version();
+	$cached_lookup = wp_cache_get( $cache_key, 'thumbnail_remover' );
+
+	if ( is_array( $cached_lookup ) ) {
+		$lookup = $cached_lookup;
+		return $lookup;
+	}
+
+	$featured_ids = $wpdb->get_col( "SELECT DISTINCT meta_value FROM {$wpdb->postmeta} WHERE meta_key = '_thumbnail_id' AND meta_value != ''" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+
+	foreach ( $featured_ids as $featured_id ) {
+		$lookup[ (int) $featured_id ] = true;
+	}
+
+	$parent_statuses = trpl_get_usage_query_statuses();
+	$status_placeholders = implode( ', ', array_fill( 0, count( $parent_statuses ), '%s' ) );
+	$parented_ids = $wpdb->get_col(
+		$wpdb->prepare(
+			"
+			SELECT child.ID
+			FROM {$wpdb->posts} child
+			INNER JOIN {$wpdb->posts} parent ON parent.ID = child.post_parent
+			WHERE child.post_type = 'attachment'
+				AND child.post_status = 'inherit'
+				AND child.post_parent > 0
+				AND parent.post_status IN ($status_placeholders)
+			",
+			$parent_statuses
+		)
+	); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+
+	foreach ( $parented_ids as $parented_id ) {
+		$lookup[ (int) $parented_id ] = true;
+	}
+
+	wp_cache_set( $cache_key, $lookup, 'thumbnail_remover', trpl_get_cache_ttl() );
+
+	return $lookup;
+}
+
+function trpl_attachment_usage_search_exists( $needle ) {
+	global $wpdb;
+	static $search_cache = array();
+
+	if ( isset( $search_cache[ $needle ] ) ) {
+		return $search_cache[ $needle ];
+	}
+
+	$cache_key = 'attachment_usage_search_' . md5( $needle . '|' . trpl_get_cache_version() );
+	$cached_result = wp_cache_get( $cache_key, 'thumbnail_remover' );
+
+	if ( false !== $cached_result ) {
+		$search_cache[ $needle ] = (bool) $cached_result;
+		return $search_cache[ $needle ];
+	}
+
+	$like = '%' . $wpdb->esc_like( $needle ) . '%';
+	$result = (int) $wpdb->get_var(
+		$wpdb->prepare(
+			"
+			SELECT (
+				EXISTS(
+					SELECT 1
+					FROM {$wpdb->posts}
+					WHERE post_type != 'attachment'
+						AND post_status NOT IN ('trash', 'auto-draft')
+						AND post_content LIKE %s
+				)
+				OR EXISTS(
+					SELECT 1
+					FROM {$wpdb->postmeta} pm
+					INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+					WHERE p.post_type != 'attachment'
+						AND p.post_status NOT IN ('trash', 'auto-draft')
+						AND pm.meta_value LIKE %s
+				)
+			)
+			",
+			$like,
+			$like
+		)
+	); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+
+	$search_cache[ $needle ] = $result > 0;
+	wp_cache_set( $cache_key, $search_cache[ $needle ], 'thumbnail_remover', trpl_get_cache_ttl() );
+
+	return $search_cache[ $needle ];
 }
 
 function trpl_build_unused_media_entry( $attachment_id ) {


### PR DESCRIPTION
## Summary
- fix the WordPress plugin-check failure by removing the `$sql`-based prepare pattern and caching the direct query lookups with `wp_cache_*`
- keep the attachment usage optimization in place while making the database access acceptable for release validation
- move release version preparation to Husky `pre-push` on `main`, so the plugin version, readme stable tag, package metadata, WordPress.org deploy, GitHub tag, and GitHub release all come from the same locally prepared version
- make CI fail if `main` was pushed without the expected local release commit, so GitHub Actions cannot release an unprepared version

## Technical notes
- `scripts/release.mjs prepare-push` now creates a local `chore(release): vX.Y.Z` commit before the real push proceeds
- the first `git push origin main` will stop after creating the release commit; the second push will publish that exact version
- `package-lock.json` root version is now updated together with `package.json`

## Testing
- `php -l thumbnail-remover.php`
- `node scripts/release.mjs verify`

## Manual review
This PR is intended for manual review before merge.
