### PR TITLE
[Issue #7] Backup and Restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Instead of removing thumbnails with a single irreversible step, the current rele
 - Reporting and recent activity logs
 - Advanced filters for format, usage status, and orphan-only cleanup
 - Existing image-size disable controls
-- Zip backups for uploads
+- Zip backups for uploads and cleanup batches
 - Scheduled cleanup with configurable frequency and scope
 
 ## Main Features
@@ -52,6 +52,8 @@ Preview cleanup before acting. The plugin shows:
 ### Trash / Restore
 
 Matching thumbnails are moved into plugin Trash instead of being deleted permanently. You can restore a trash batch later from the same admin screen.
+
+Cleanup can also create a zip backup of the exact matching thumbnails before they are moved, and the backup remains downloadable from the Trash batch table.
 
 ### Batch Processing
 
@@ -114,7 +116,7 @@ Review recent media operations from the admin screen, including analysis runs, p
 
 1. Run **Full Analysis**
 2. Review per-size analytics, orphan counts, and probably unused media
-3. Create a backup zip if needed
+3. Keep the cleanup backup option enabled, or create a broader uploads backup if needed
 4. Use **Preview Cleanup**
 5. Move matching thumbnails to **Trash**
 6. Restore a batch if you need to reverse the cleanup
@@ -156,7 +158,7 @@ It is designed to be safer on larger sites than one-click cleanup tools. Analysi
 
 ### Can I back up uploads before cleanup?
 
-Yes. You can create a zip backup for all uploads or only a selected year/month uploads folder before making cleanup changes.
+Yes. Cleanup can create a zip backup of the exact matching thumbnails before moving them to Trash. You can also create a broader zip backup for all uploads or only a selected year/month uploads folder before making cleanup changes.
 
 ### Can I restore only one cleanup batch?
 
@@ -188,6 +190,8 @@ No. Scheduled cleanup also moves matching files into plugin Trash first. The mai
 
 ### Unreleased
 
+- Added optional zip backups for matching thumbnails before they are moved to plugin Trash
+- Stored cleanup backup links with Trash batches so previous cleanup backups remain downloadable
 - Added advanced filters for image format, attachment usage, and orphan-only versus tracked thumbnail cleanup
 - Reused the same filters across analysis, preview cleanup, and regeneration workflows
 - Updated the admin UI and docs to explain the new filtering options

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -235,6 +235,7 @@ jQuery(function ($) {
 
 		const sizes = collectValues('#trpl-delete-form input[name="sizes[]"]:checked');
 		const folders = collectValues('#trpl-delete-form input[name="folders[]"]:checked');
+		const backupBeforeDelete = $("#trpl-backup-before-delete").is(":checked") ? 1 : 0;
 		const $progress = $("#trpl-delete-progress");
 		const $results = $("#trpl-delete-results");
 		setProgress($progress, 0);
@@ -243,12 +244,13 @@ jQuery(function ($) {
 		runJob({
 			startAction: "trpl_start_delete",
 			processAction: "trpl_process_delete",
-			startData: $.extend({ sizes: sizes, folders: folders }, collectFilters("#trpl-delete-form")),
+			startData: $.extend({ sizes: sizes, folders: folders, backup_before_delete: backupBeforeDelete }, collectFilters("#trpl-delete-form")),
 			onProgress: function (data) {
 				setProgress($progress, data.progress);
 			},
 			onComplete: function (data, startData) {
 				hideProgress($progress);
+				const backupUrl = data.backup_url || startData.backup_url || "";
 				const message =
 					"Moved " +
 					(data.result.moved || 0) +
@@ -258,7 +260,8 @@ jQuery(function ($) {
 					(data.result.orphans || 0) +
 					". Trash batch: <code>" +
 					(startData.trash_batch_id || data.trash_batch_id || "") +
-					"</code>.";
+					"</code>." +
+					(backupUrl ? ' <a class="button button-secondary" href="' + backupUrl + '">Download Backup</a>' : "");
 				renderNotice($results, message, "success");
 			},
 			onError: function (error) {

--- a/readme.txt
+++ b/readme.txt
@@ -19,6 +19,7 @@ Instead of deleting thumbnails blindly, the plugin now helps you:
 
 * Preview cleanup results before removing files
 * Move thumbnails to plugin Trash instead of deleting permanently
+* Create a zip backup of the exact matching thumbnails before moving them to Trash
 * Restore trashed thumbnails later if needed
 * Process large libraries in batches with visible progress
 * Detect orphan thumbnails left behind on disk
@@ -36,6 +37,7 @@ This release is built for site owners, developers, agencies, and anyone trying t
 
 * Dry run / preview before cleanup
 * Trash and Restore workflow for safer deletion
+* Optional zip backup before moving matching thumbnails to Trash
 * Batch processing with real progress for scan, cleanup, and regeneration
 * Unused media detection
 * Orphan thumbnail detection
@@ -82,7 +84,7 @@ Yes. The advanced filters can narrow analysis, cleanup, and regeneration jobs by
 Yes. Analysis, cleanup, and regeneration are processed in batches with visible progress to reduce timeout problems on larger WordPress sites.
 
 = Can I back up my files before cleanup? =
-Yes. You can create a zip backup for all uploads or for a selected year/month folder.
+Yes. You can create a zip backup for all uploads or for a selected year/month folder, and cleanup can also create a zip backup of the exact matching thumbnails before they are moved to plugin Trash.
 
 = Can I restore only one cleanup batch instead of everything? =
 Yes. Each cleanup run creates its own Trash batch, so you can restore a specific batch independently.
@@ -109,6 +111,8 @@ No. The plugin marks items as probably unused based on several WordPress relatio
 == Changelog ==
 
 = Unreleased =
+* Added optional zip backups for matching thumbnails before they are moved to plugin Trash
+* Stored cleanup backup links with Trash batches so previous cleanup backups remain downloadable from the Trash and Restore table
 * Added advanced filters for image format, attachment usage, and orphan-only versus tracked cleanup
 * Reused the new filters across analysis, preview cleanup, and regeneration workflows
 * Updated the admin UI and documentation to explain the extra filtering controls

--- a/thumbnail-remover.php
+++ b/thumbnail-remover.php
@@ -518,6 +518,20 @@ function trpl_get_upload_base_url() {
 	return trailingslashit( $upload_dir['baseurl'] );
 }
 
+function trpl_upload_path_to_url( $path ) {
+	$base_dir = wp_normalize_path( trpl_get_upload_base_dir() );
+	$path = wp_normalize_path( $path );
+
+	if ( 0 !== strpos( $path, $base_dir ) ) {
+		return '';
+	}
+
+	$relative_path = ltrim( substr( $path, strlen( $base_dir ) ), '/' );
+	$encoded_path = implode( '/', array_map( 'rawurlencode', explode( '/', $relative_path ) ) );
+
+	return trpl_get_upload_base_url() . $encoded_path;
+}
+
 function trpl_get_cache_version() {
 	$version = (int) get_option( TRPL_CACHE_VERSION_OPTION, 1 );
 
@@ -1355,6 +1369,7 @@ function trpl_create_trash_batch() {
 	$batch_id = gmdate( 'Ymd-His' ) . '-' . wp_generate_password( 6, false, false );
 	$batch_dir = trpl_get_trash_base_dir() . $batch_id . '/';
 	trpl_ensure_directory( $batch_dir . 'files/' );
+	trpl_ensure_directory( $batch_dir . 'backups/' );
 
 	$manifest = array(
 		'id' => $batch_id,
@@ -1363,6 +1378,7 @@ function trpl_create_trash_batch() {
 		'status' => 'active',
 		'items' => array(),
 		'total_bytes' => 0,
+		'backup' => array(),
 	);
 	trpl_write_trash_manifest( $batch_id, $manifest );
 
@@ -1375,6 +1391,14 @@ function trpl_get_trash_manifest_path( $batch_id ) {
 
 function trpl_delete_trash_batch( $batch_id ) {
 	return trpl_delete_directory( trpl_get_trash_base_dir() . $batch_id );
+}
+
+function trpl_get_trash_batch_backup_url( $batch ) {
+	if ( empty( $batch['backup']['path'] ) ) {
+		return '';
+	}
+
+	return trpl_upload_path_to_url( trpl_get_upload_base_dir() . ltrim( $batch['backup']['path'], '/' ) );
 }
 
 function trpl_write_trash_manifest( $batch_id, $manifest ) {
@@ -1401,6 +1425,72 @@ function trpl_read_trash_manifest( $batch_id ) {
 
 	$manifest = json_decode( $filesystem->get_contents( $path ), true );
 	return is_array( $manifest ) ? $manifest : null;
+}
+
+function trpl_create_trash_batch_backup( $batch_id, $records ) {
+	$records = is_array( $records ) ? $records : array();
+
+	if ( empty( $records ) ) {
+		return array();
+	}
+
+	$batch_dir = trpl_get_trash_base_dir() . $batch_id . '/';
+	$backup_dir = $batch_dir . 'backups/';
+	trpl_ensure_directory( $backup_dir );
+
+	$zip_file = $backup_dir . 'removed-thumbnails-' . $batch_id . '.zip';
+	$upload_base_dir = trpl_get_upload_base_dir();
+	$file_paths = array();
+	$total_bytes = 0;
+
+	foreach ( $records as $record ) {
+		$file_path = isset( $record['path'] ) ? (string) $record['path'] : '';
+
+		if ( ! $file_path || ! file_exists( $file_path ) || ! is_file( $file_path ) || ! trpl_is_supported_image_path( $file_path ) ) {
+			continue;
+		}
+
+		$normalized_path = wp_normalize_path( $file_path );
+		if ( 0 !== strpos( $normalized_path, wp_normalize_path( $upload_base_dir ) ) ) {
+			continue;
+		}
+
+		$file_paths[] = $file_path;
+		$total_bytes += (int) filesize( $file_path );
+	}
+
+	if ( empty( $file_paths ) ) {
+		return array();
+	}
+
+	if ( class_exists( 'ZipArchive' ) ) {
+		$zip = new ZipArchive();
+		if ( true !== $zip->open( $zip_file, ZipArchive::CREATE | ZipArchive::OVERWRITE ) ) {
+			return false;
+		}
+
+		foreach ( $file_paths as $file_path ) {
+			$relative_path = ltrim( str_replace( wp_normalize_path( $upload_base_dir ), '', wp_normalize_path( $file_path ) ), '/' );
+			$zip->addFile( $file_path, $relative_path );
+		}
+
+		$zip->close();
+	} else {
+		require_once ABSPATH . 'wp-admin/includes/class-pclzip.php';
+		$archive = new PclZip( $zip_file );
+		$result = $archive->create( $file_paths, PCLZIP_OPT_REMOVE_PATH, $upload_base_dir );
+		if ( 0 === $result ) {
+			return false;
+		}
+	}
+
+	return array(
+		'path' => ltrim( str_replace( wp_normalize_path( $upload_base_dir ), '', wp_normalize_path( $zip_file ) ), '/' ),
+		'filename' => basename( $zip_file ),
+		'files' => count( $file_paths ),
+		'bytes' => $total_bytes,
+		'created_at' => time(),
+	);
 }
 
 function trpl_move_file_to_trash( $batch_id, $record ) {
@@ -1616,10 +1706,27 @@ function trpl_process_analysis_job( &$job, $batch_size = 12 ) {
 	return $job['processed'] >= $job['total'];
 }
 
-function trpl_create_delete_job( $selected_sizes, $selected_folders, $filters = array() ) {
+function trpl_create_delete_job( $selected_sizes, $selected_folders, $filters = array(), $backup_before_delete = false ) {
 	$filters = trpl_sanitize_advanced_filters( $filters );
 	$candidates = trpl_build_removal_candidates( $selected_sizes, $selected_folders, $filters );
 	$batch_id = trpl_create_trash_batch();
+	$backup = array();
+
+	if ( $backup_before_delete && ! empty( $candidates ) ) {
+		$backup = trpl_create_trash_batch_backup( $batch_id, $candidates );
+
+		if ( false === $backup ) {
+			trpl_delete_trash_batch( $batch_id );
+
+			return new WP_Error( 'trpl_backup_failed', __( 'Failed to create a zip backup before moving files to Trash.', 'thumbnail-remover' ) );
+		}
+
+		$manifest = trpl_read_trash_manifest( $batch_id );
+		if ( $manifest ) {
+			$manifest['backup'] = $backup;
+			trpl_write_trash_manifest( $batch_id, $manifest );
+		}
+	}
 
 	return trpl_start_job(
 		'delete',
@@ -1631,6 +1738,7 @@ function trpl_create_delete_job( $selected_sizes, $selected_folders, $filters = 
 			'selected_folders' => $selected_folders,
 			'filters' => $filters,
 			'trash_batch_id' => $batch_id,
+			'backup' => $backup,
 			'result' => array(
 				'moved' => 0,
 				'bytes' => 0,
@@ -1836,13 +1944,19 @@ function trpl_ajax_start_delete() {
 	$selected_sizes = trpl_normalize_text_list( trpl_get_post_array_input( 'sizes' ) );
 	$selected_folders = trpl_normalize_text_list( trpl_get_post_array_input( 'folders' ) );
 	$filters = trpl_get_request_advanced_filters();
-	$job = trpl_create_delete_job( $selected_sizes, $selected_folders, $filters );
+	$backup_before_delete = (bool) trpl_get_post_scalar_input( 'backup_before_delete' );
+	$job = trpl_create_delete_job( $selected_sizes, $selected_folders, $filters, $backup_before_delete );
+
+	if ( is_wp_error( $job ) ) {
+		wp_send_json_error( array( 'message' => $job->get_error_message() ) );
+	}
 
 	wp_send_json_success(
 		array(
 			'job_id' => $job['id'],
 			'total' => $job['total'],
 			'trash_batch_id' => $job['trash_batch_id'],
+			'backup_url' => ! empty( $job['backup']['path'] ) ? trpl_upload_path_to_url( trpl_get_upload_base_dir() . $job['backup']['path'] ) : '',
 		)
 	);
 }
@@ -1872,12 +1986,29 @@ function trpl_ajax_process_delete() {
 	if ( $is_complete ) {
 		$response['result'] = $job['result'];
 		$response['trash_batch_id'] = $job['trash_batch_id'];
+		$response['backup_url'] = ! empty( $job['backup']['path'] ) ? trpl_upload_path_to_url( trpl_get_upload_base_dir() . $job['backup']['path'] ) : '';
 		if ( 'scheduled_cleanup' !== ( isset( $job['source'] ) ? $job['source'] : 'manual' ) ) {
+			if ( ! empty( $job['backup']['path'] ) ) {
+				trpl_add_activity_log(
+					array(
+						'action' => 'backup',
+						'status' => 'success',
+						'message' => __( 'Cleanup backup created before moving thumbnails to Trash.', 'thumbnail-remover' ),
+						'job_id' => $job['id'],
+						'batch_id' => $job['trash_batch_id'],
+						'files' => isset( $job['backup']['files'] ) ? (int) $job['backup']['files'] : 0,
+						'bytes' => isset( $job['backup']['bytes'] ) ? (int) $job['backup']['bytes'] : 0,
+						'sizes' => isset( $job['selected_sizes'] ) ? $job['selected_sizes'] : array(),
+						'folders' => isset( $job['selected_folders'] ) ? $job['selected_folders'] : array(),
+					)
+				);
+			}
+
 			trpl_add_activity_log(
 				array(
 					'action' => 'delete',
 					'status' => 'success',
-					'message' => __( 'Matching thumbnails were moved to Trash.', 'thumbnail-remover' ),
+					'message' => ! empty( $job['backup']['path'] ) ? __( 'Matching thumbnails were backed up and moved to Trash.', 'thumbnail-remover' ) : __( 'Matching thumbnails were moved to Trash.', 'thumbnail-remover' ),
 					'job_id' => $job['id'],
 					'batch_id' => $job['trash_batch_id'],
 					'files' => (int) $job['result']['moved'],
@@ -2588,6 +2719,13 @@ function trpl_admin_page() {
 					</ul>
 					<?php trpl_render_advanced_filter_fields( 'delete', $default_filters, array( 'include_source' => true ) ); ?>
 
+					<p>
+						<label>
+							<input type="checkbox" id="trpl-backup-before-delete" name="backup_before_delete" value="1" checked>
+							<?php esc_html_e( 'Create a zip backup of matching thumbnails before moving them to Trash', 'thumbnail-remover' ); ?>
+						</label>
+					</p>
+
 					<p class="trpl-action-row">
 						<button type="button" class="button" id="trpl-preview-delete"><?php esc_html_e( 'Preview Cleanup', 'thumbnail-remover' ); ?></button>
 						<button type="submit" class="button button-primary" id="trpl-start-delete"><?php esc_html_e( 'Move Matching Files to Trash', 'thumbnail-remover' ); ?></button>
@@ -2614,11 +2752,12 @@ function trpl_admin_page() {
 							<th><?php esc_html_e( 'Size', 'thumbnail-remover' ); ?></th>
 							<th><?php esc_html_e( 'Status', 'thumbnail-remover' ); ?></th>
 							<th><?php esc_html_e( 'Action', 'thumbnail-remover' ); ?></th>
+							<th><?php esc_html_e( 'Backup', 'thumbnail-remover' ); ?></th>
 						</tr>
 					</thead>
 					<tbody id="trpl-trash-table-body">
 						<?php if ( empty( $trash_batches ) ) : ?>
-							<tr><td colspan="6"><?php esc_html_e( 'Trash is empty.', 'thumbnail-remover' ); ?></td></tr>
+							<tr><td colspan="7"><?php esc_html_e( 'Trash is empty.', 'thumbnail-remover' ); ?></td></tr>
 						<?php else : ?>
 							<?php foreach ( $trash_batches as $batch ) : ?>
 								<tr data-batch-id="<?php echo esc_attr( $batch['id'] ); ?>">
@@ -2632,6 +2771,14 @@ function trpl_admin_page() {
 											<button type="button" class="button trpl-restore-trash" data-batch-id="<?php echo esc_attr( $batch['id'] ); ?>"><?php esc_html_e( 'Restore', 'thumbnail-remover' ); ?></button>
 										<?php else : ?>
 											<?php esc_html_e( 'Already restored', 'thumbnail-remover' ); ?>
+										<?php endif; ?>
+									</td>
+									<td>
+										<?php $backup_url = trpl_get_trash_batch_backup_url( $batch ); ?>
+										<?php if ( $backup_url ) : ?>
+											<a class="button button-secondary" href="<?php echo esc_url( $backup_url ); ?>"><?php esc_html_e( 'Download', 'thumbnail-remover' ); ?></a>
+										<?php else : ?>
+											<?php esc_html_e( 'Not created', 'thumbnail-remover' ); ?>
 										<?php endif; ?>
 									</td>
 								</tr>


### PR DESCRIPTION
Implements issue #7: Backup and Restore.\n\nSummary:\n- Adds an enabled-by-default cleanup option to create a zip backup of matching thumbnails before they are moved to plugin Trash.\n- Stores backup metadata in each Trash batch manifest and exposes a Download action in the Trash and Restore table.\n- Returns backup download URLs from the delete job flow so the completion notice can link directly to the generated zip.\n- Logs cleanup backup activity separately from the Trash move and updates README/readme documentation.\n\nTechnical notes:\n- The backup zip is created before any matching files are moved. If zip creation fails, the cleanup job is not started and the temporary Trash batch is removed.\n- Existing Trash restore behavior is preserved and continues to restore batch files from plugin Trash.\n- Scheduled cleanup continues without automatic zip backup to avoid unexpected unattended archive growth.\n\nLimitations / follow-up:\n- No new automated test framework was added because this plugin does not currently include one.\n\nTesting:\n- php -l thumbnail-remover.php\n- git diff --check\n\nThis PR is intended for manual review before merge.